### PR TITLE
:bug: PercyDOM.serialize returns object now

### DIFF
--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -119,7 +119,7 @@ namespace PercyIO.Selenium
                     driver.ExecuteScript(GetPercyDOM());
 
                 string opts = JsonSerializer.Serialize(options);
-                string domSnapshot = (string) driver.ExecuteScript($"return PercyDOM.serialize({opts})");
+                var domSnapshot = driver.ExecuteScript($"return PercyDOM.serialize({opts})");
 
                 Options snapshotOptions = new Options {
                     { "clientInfo", CLIENT_INFO },

--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@
 
 [Percy](https://percy.io) visual testing for .NET Selenium.
 
+## Development
+
+Install/update `@percy/cli` dev dependency (requires Node 14+):
+
+```sh-session
+$ npm install --save-dev @percy/cli
+```
+
+Install dotnet SDK:
+
+```sh-session
+$ brew tap isen-ng/dotnet-sdk-versions
+$ brew install --cask  dotnet-sdk5-0-400
+$ dotnet --list-sdks
+```
+
+Install Mono:
+
+```sh-session
+$ brew install mono
+$ mono --version 
+```
+
+Run tests:
+
+```
+npm run test
+```
+
 ## Installation
 
 npm install `@percy/cli` (requires Node 14+):
@@ -13,7 +42,7 @@ $ npm install --save-dev @percy/cli
 
 Install the PercyIO.Selenium package (for example, with .NET CLI):
 
-```ssh-session
+```sh-session
 $ dotnet add package PercyIO.Selenium
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@percy/cli": "^1.12.0"
+        "@percy/cli": "^1.16.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -79,20 +79,20 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.12.0.tgz",
-      "integrity": "sha512-cWp6enOQP/DB0EqJK7F+KznjpLEis5JaAVHSoKkYiSQMsNgNhwMq6IgTSkTbu+ZfUqr3n8s5SL02JVIsgRgXyQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.16.0.tgz",
+      "integrity": "sha512-ICvtqlCVFnyUO3hJjza5CzeCDiA8dzfzZEmDf3pBxQox2p1xlO/p6/HE+8OR8vi8xNwNU+iytEfbpl0t8NQxHw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-app": "1.12.0",
-        "@percy/cli-build": "1.12.0",
-        "@percy/cli-command": "1.12.0",
-        "@percy/cli-config": "1.12.0",
-        "@percy/cli-exec": "1.12.0",
-        "@percy/cli-snapshot": "1.12.0",
-        "@percy/cli-upload": "1.12.0",
-        "@percy/client": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/cli-app": "1.16.0",
+        "@percy/cli-build": "1.16.0",
+        "@percy/cli-command": "1.16.0",
+        "@percy/cli-config": "1.16.0",
+        "@percy/cli-exec": "1.16.0",
+        "@percy/cli-snapshot": "1.16.0",
+        "@percy/cli-upload": "1.16.0",
+        "@percy/client": "1.16.0",
+        "@percy/logger": "1.16.0"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -102,39 +102,39 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.12.0.tgz",
-      "integrity": "sha512-vS002JnlGyu8CxIY69WXGvgZn7RillBM4MOyAtFmT2r/u8KUsUTslJ3pIimXQMeC7jFnwkEK2bxfcstoBNv5hA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.16.0.tgz",
+      "integrity": "sha512-Igmkod0vGcBj1KSB5JZrKoXuUSRPuceHVm+BjR23R5O/Gv9whKT7Zn1wEGhWNTS7cFz0B0Qg9uKiqjUcU9jNHQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0",
-        "@percy/cli-exec": "1.12.0"
+        "@percy/cli-command": "1.16.0",
+        "@percy/cli-exec": "1.16.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.12.0.tgz",
-      "integrity": "sha512-O18xPFuCsrsyUgpkozTsvQCvqQkv/y3dj5cDiGzwMI+fI2B+jdCIEri6J/ZEWw78CGPQSCrBO0ufKK2qHd5wVw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.16.0.tgz",
+      "integrity": "sha512-23rEYqwCtpXprvduwEOAlQLfOZhO0KTVMNM/25nrmiOwPvcEcB8cLeGdCq48JNR3GvbZrDaXP8UxJaCmkTiZow==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0"
+        "@percy/cli-command": "1.16.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.12.0.tgz",
-      "integrity": "sha512-D7wy/r/HczO0dz8IfBiZP7kquMocPtiAd8rTYdEDBKkWyiC+bKGgYAbV3MzYAFgwRkXpswRbbPgq3exXp19oLg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.16.0.tgz",
+      "integrity": "sha512-MXRyDA9iRfFTVpSL/+GWEGnB19EU+qb16u1fdSHlSp/BHNiGIFmF2yRw4TepAKkiYuJmzFNyqEcdKAnwWB77qA==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.12.0",
-        "@percy/core": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/config": "1.16.0",
+        "@percy/core": "1.16.0",
+        "@percy/logger": "1.16.0"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -144,24 +144,24 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.12.0.tgz",
-      "integrity": "sha512-ae3cEjFCrVZz9yexj3+VjYFNZMvRYsZ9DI6MHxcujb72DRmnG5Xs0ZnAThx3pkSrRNOWViAJxcNE2AIBtkKQsQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.16.0.tgz",
+      "integrity": "sha512-wsGGpqhcFVjRoq9sZl9LxKho5FOaasSYzxBlNGnfbrcCxZEhSmiszoss/115IgBaioSFBwybu3z0crGhbffS5g==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0"
+        "@percy/cli-command": "1.16.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.12.0.tgz",
-      "integrity": "sha512-UdZQs1GcttqabgV7Md8p/UsgJLiwaeZ7pI4nQ5bGQ0LBa1F5c/so2pX0MUcQqeUt5Vy9P8mixCSD+OI+djlzKw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.16.0.tgz",
+      "integrity": "sha512-INZA1lCATlTpZLxd3GeWzbxd3dARsBYW/NvtnlWNs5svoMHYgzjNqraodZFfKLCdmiZ4uH2D6az8P/Ho4h+4Fw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -170,12 +170,12 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.12.0.tgz",
-      "integrity": "sha512-kKgdj6HSMaF9QDhYg8wZvlHftj+d2Nq+g1pWmRrtsCGJH5aNEORU1396fs7t7WBUZagy9O7lzLzZ+xxPoTa1og==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.16.0.tgz",
+      "integrity": "sha512-t92+vTWxfL/5BLZncMy9yWgTIvwDuANXEfCb3EjWuW5s9WY0rlG/Vl+LMY4wffDyT+Kcc63dW7kQSgSLS7t/bw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -183,12 +183,12 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.12.0.tgz",
-      "integrity": "sha512-caK70dxhew9/wbVwJp6cp5CU66oTOXJdVQjBqfvWqqG1qGMqeA+mYYzG2XMtDOGs8CLD61IRJHkBOBL6vTVjnA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.16.0.tgz",
+      "integrity": "sha512-syRiw/wAuW7z644SspgAgEjcf7xtiY7mxEqXjJFuhxa3nYm1TjTSgYsQHecYAOhWAc4rbngNnVNuben3F8mqFg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -197,25 +197,25 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.12.0.tgz",
-      "integrity": "sha512-KQJ8ykLteQwf8ldTJPh8szLqmJpMJvVG7d7+TVnkYKpNJRhsGEqHnymhKADGWn5/U6i0Z8DdEJGExfnABmRB1A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.16.0.tgz",
+      "integrity": "sha512-P0vbuKIE2H5lk/47HWDM6T8bJzv9pBQjY5LFQ3vQdvsRWah2fY/EV02D5WLh4qyBow5RdnFrbpV24oRKs1tX9A==",
       "dev": true,
       "dependencies": {
-        "@percy/env": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/env": "1.16.0",
+        "@percy/logger": "1.16.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.12.0.tgz",
-      "integrity": "sha512-4ECAofbnlyP10PxNeiE8hlEG+IvqCNQ/R8V9on2EGD68mo9E7gsD9zWfMpVHuFNxCQxC0FYinR7VWaQVBvIb6Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.16.0.tgz",
+      "integrity": "sha512-yF9iYh9HwoRgCAeHcYG4tZMsU8fv4lL+YNQPdJazxBMnNxxMegxFGMf51gMbn5OBallRjRlWMnOif0IiQz4Siw==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.12.0",
+        "@percy/logger": "1.16.0",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
         "yaml": "^2.0.0"
@@ -225,16 +225,16 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.12.0.tgz",
-      "integrity": "sha512-djjyRDQ/fSYc5n4L952fezMamXA4coNCSnCOIuV1tuul6HP2QpQBqSLUlTNIqtCy1vWUYQQvz6WtCzSw8Fp08g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.16.0.tgz",
+      "integrity": "sha512-J342BLq7DY5Z/2EX5z2XYGftS/yRAf7FKTcT4J40VB4c6dX54e0uMm+t7yu/djkFEdbzXQvMWuGGaQj3WYW+4w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.12.0",
-        "@percy/config": "1.12.0",
-        "@percy/dom": "1.12.0",
-        "@percy/logger": "1.12.0",
+        "@percy/client": "1.16.0",
+        "@percy/config": "1.16.0",
+        "@percy/dom": "1.16.0",
+        "@percy/logger": "1.16.0",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -250,33 +250,33 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.12.0.tgz",
-      "integrity": "sha512-EUy281hPhpPqdy9DV3OXROOK2B7p0nujox/n18MmgWwxlO4YxVQJC0C3VF7TmHIhGBwE8BLSqxqz6r1RramKyw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.16.0.tgz",
+      "integrity": "sha512-jAH9gwQ8vjRm6EAYlk59b5je4jlqh+lM7YiGADCxwHDpbAvgJxu/getnaNAxvygeXnmTn87ZwInPhIa4WeBYIg==",
       "dev": true
     },
     "node_modules/@percy/env": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.12.0.tgz",
-      "integrity": "sha512-baEMvDcVzbJcOL+rr4s98Jb7tKdUVWnNGdXZI26UxsaSwHtKJRceHe4Qzw79FPU1KtJnK34KEsCDj4S9eAtGEg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.16.0.tgz",
+      "integrity": "sha512-MRyUk5fQ9EXNVirupSYX5OaMAsvE7db8OVeJrM2RyzcEB16xMmI5rpj7HPu7eTU6Spe0KXbqaDze3Slr5aPHpA==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.12.0.tgz",
-      "integrity": "sha512-GQ9XiwOK9sb+5luZH4899Wwt1RF6K5fkiyumjYrZk4MtkxOqVIUtU08rat0rZZUO0T+KkNHvjbZ487XvLQjN1g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.16.0.tgz",
+      "integrity": "sha512-u9zTj6BcUmqknrcikrunRpkRr+uQlENhgK/m0Zokxtv9CgkmNzR8oLoseJjU5P4zGZEiJE/v7wnzNC1ezvS9nQ==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.4.tgz",
-      "integrity": "sha512-BxcJpBu8D3kv/GZkx/gSMz6VnTJREBj/4lbzYOQueUOELkt8WrO6zAcSPmp9uRPEW/d+lUO8QK0W2xnS1hEU0A==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true,
       "optional": true
     },
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -1108,9 +1108,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -1202,125 +1202,125 @@
       }
     },
     "@percy/cli": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.12.0.tgz",
-      "integrity": "sha512-cWp6enOQP/DB0EqJK7F+KznjpLEis5JaAVHSoKkYiSQMsNgNhwMq6IgTSkTbu+ZfUqr3n8s5SL02JVIsgRgXyQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.16.0.tgz",
+      "integrity": "sha512-ICvtqlCVFnyUO3hJjza5CzeCDiA8dzfzZEmDf3pBxQox2p1xlO/p6/HE+8OR8vi8xNwNU+iytEfbpl0t8NQxHw==",
       "dev": true,
       "requires": {
-        "@percy/cli-app": "1.12.0",
-        "@percy/cli-build": "1.12.0",
-        "@percy/cli-command": "1.12.0",
-        "@percy/cli-config": "1.12.0",
-        "@percy/cli-exec": "1.12.0",
-        "@percy/cli-snapshot": "1.12.0",
-        "@percy/cli-upload": "1.12.0",
-        "@percy/client": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/cli-app": "1.16.0",
+        "@percy/cli-build": "1.16.0",
+        "@percy/cli-command": "1.16.0",
+        "@percy/cli-config": "1.16.0",
+        "@percy/cli-exec": "1.16.0",
+        "@percy/cli-snapshot": "1.16.0",
+        "@percy/cli-upload": "1.16.0",
+        "@percy/client": "1.16.0",
+        "@percy/logger": "1.16.0"
       }
     },
     "@percy/cli-app": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.12.0.tgz",
-      "integrity": "sha512-vS002JnlGyu8CxIY69WXGvgZn7RillBM4MOyAtFmT2r/u8KUsUTslJ3pIimXQMeC7jFnwkEK2bxfcstoBNv5hA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.16.0.tgz",
+      "integrity": "sha512-Igmkod0vGcBj1KSB5JZrKoXuUSRPuceHVm+BjR23R5O/Gv9whKT7Zn1wEGhWNTS7cFz0B0Qg9uKiqjUcU9jNHQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0",
-        "@percy/cli-exec": "1.12.0"
+        "@percy/cli-command": "1.16.0",
+        "@percy/cli-exec": "1.16.0"
       }
     },
     "@percy/cli-build": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.12.0.tgz",
-      "integrity": "sha512-O18xPFuCsrsyUgpkozTsvQCvqQkv/y3dj5cDiGzwMI+fI2B+jdCIEri6J/ZEWw78CGPQSCrBO0ufKK2qHd5wVw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.16.0.tgz",
+      "integrity": "sha512-23rEYqwCtpXprvduwEOAlQLfOZhO0KTVMNM/25nrmiOwPvcEcB8cLeGdCq48JNR3GvbZrDaXP8UxJaCmkTiZow==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0"
+        "@percy/cli-command": "1.16.0"
       }
     },
     "@percy/cli-command": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.12.0.tgz",
-      "integrity": "sha512-D7wy/r/HczO0dz8IfBiZP7kquMocPtiAd8rTYdEDBKkWyiC+bKGgYAbV3MzYAFgwRkXpswRbbPgq3exXp19oLg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.16.0.tgz",
+      "integrity": "sha512-MXRyDA9iRfFTVpSL/+GWEGnB19EU+qb16u1fdSHlSp/BHNiGIFmF2yRw4TepAKkiYuJmzFNyqEcdKAnwWB77qA==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.12.0",
-        "@percy/core": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/config": "1.16.0",
+        "@percy/core": "1.16.0",
+        "@percy/logger": "1.16.0"
       }
     },
     "@percy/cli-config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.12.0.tgz",
-      "integrity": "sha512-ae3cEjFCrVZz9yexj3+VjYFNZMvRYsZ9DI6MHxcujb72DRmnG5Xs0ZnAThx3pkSrRNOWViAJxcNE2AIBtkKQsQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.16.0.tgz",
+      "integrity": "sha512-wsGGpqhcFVjRoq9sZl9LxKho5FOaasSYzxBlNGnfbrcCxZEhSmiszoss/115IgBaioSFBwybu3z0crGhbffS5g==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0"
+        "@percy/cli-command": "1.16.0"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.12.0.tgz",
-      "integrity": "sha512-UdZQs1GcttqabgV7Md8p/UsgJLiwaeZ7pI4nQ5bGQ0LBa1F5c/so2pX0MUcQqeUt5Vy9P8mixCSD+OI+djlzKw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.16.0.tgz",
+      "integrity": "sha512-INZA1lCATlTpZLxd3GeWzbxd3dARsBYW/NvtnlWNs5svoMHYgzjNqraodZFfKLCdmiZ4uH2D6az8P/Ho4h+4Fw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.12.0.tgz",
-      "integrity": "sha512-kKgdj6HSMaF9QDhYg8wZvlHftj+d2Nq+g1pWmRrtsCGJH5aNEORU1396fs7t7WBUZagy9O7lzLzZ+xxPoTa1og==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.16.0.tgz",
+      "integrity": "sha512-t92+vTWxfL/5BLZncMy9yWgTIvwDuANXEfCb3EjWuW5s9WY0rlG/Vl+LMY4wffDyT+Kcc63dW7kQSgSLS7t/bw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "yaml": "^2.0.0"
       }
     },
     "@percy/cli-upload": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.12.0.tgz",
-      "integrity": "sha512-caK70dxhew9/wbVwJp6cp5CU66oTOXJdVQjBqfvWqqG1qGMqeA+mYYzG2XMtDOGs8CLD61IRJHkBOBL6vTVjnA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.16.0.tgz",
+      "integrity": "sha512-syRiw/wAuW7z644SspgAgEjcf7xtiY7mxEqXjJFuhxa3nYm1TjTSgYsQHecYAOhWAc4rbngNnVNuben3F8mqFg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.12.0",
+        "@percy/cli-command": "1.16.0",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.12.0.tgz",
-      "integrity": "sha512-KQJ8ykLteQwf8ldTJPh8szLqmJpMJvVG7d7+TVnkYKpNJRhsGEqHnymhKADGWn5/U6i0Z8DdEJGExfnABmRB1A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.16.0.tgz",
+      "integrity": "sha512-P0vbuKIE2H5lk/47HWDM6T8bJzv9pBQjY5LFQ3vQdvsRWah2fY/EV02D5WLh4qyBow5RdnFrbpV24oRKs1tX9A==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.12.0",
-        "@percy/logger": "1.12.0"
+        "@percy/env": "1.16.0",
+        "@percy/logger": "1.16.0"
       }
     },
     "@percy/config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.12.0.tgz",
-      "integrity": "sha512-4ECAofbnlyP10PxNeiE8hlEG+IvqCNQ/R8V9on2EGD68mo9E7gsD9zWfMpVHuFNxCQxC0FYinR7VWaQVBvIb6Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.16.0.tgz",
+      "integrity": "sha512-yF9iYh9HwoRgCAeHcYG4tZMsU8fv4lL+YNQPdJazxBMnNxxMegxFGMf51gMbn5OBallRjRlWMnOif0IiQz4Siw==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.12.0",
+        "@percy/logger": "1.16.0",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
         "yaml": "^2.0.0"
       }
     },
     "@percy/core": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.12.0.tgz",
-      "integrity": "sha512-djjyRDQ/fSYc5n4L952fezMamXA4coNCSnCOIuV1tuul6HP2QpQBqSLUlTNIqtCy1vWUYQQvz6WtCzSw8Fp08g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.16.0.tgz",
+      "integrity": "sha512-J342BLq7DY5Z/2EX5z2XYGftS/yRAf7FKTcT4J40VB4c6dX54e0uMm+t7yu/djkFEdbzXQvMWuGGaQj3WYW+4w==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.12.0",
-        "@percy/config": "1.12.0",
-        "@percy/dom": "1.12.0",
-        "@percy/logger": "1.12.0",
+        "@percy/client": "1.16.0",
+        "@percy/config": "1.16.0",
+        "@percy/dom": "1.16.0",
+        "@percy/logger": "1.16.0",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -1333,27 +1333,27 @@
       }
     },
     "@percy/dom": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.12.0.tgz",
-      "integrity": "sha512-EUy281hPhpPqdy9DV3OXROOK2B7p0nujox/n18MmgWwxlO4YxVQJC0C3VF7TmHIhGBwE8BLSqxqz6r1RramKyw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.16.0.tgz",
+      "integrity": "sha512-jAH9gwQ8vjRm6EAYlk59b5je4jlqh+lM7YiGADCxwHDpbAvgJxu/getnaNAxvygeXnmTn87ZwInPhIa4WeBYIg==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.12.0.tgz",
-      "integrity": "sha512-baEMvDcVzbJcOL+rr4s98Jb7tKdUVWnNGdXZI26UxsaSwHtKJRceHe4Qzw79FPU1KtJnK34KEsCDj4S9eAtGEg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.16.0.tgz",
+      "integrity": "sha512-MRyUk5fQ9EXNVirupSYX5OaMAsvE7db8OVeJrM2RyzcEB16xMmI5rpj7HPu7eTU6Spe0KXbqaDze3Slr5aPHpA==",
       "dev": true
     },
     "@percy/logger": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.12.0.tgz",
-      "integrity": "sha512-GQ9XiwOK9sb+5luZH4899Wwt1RF6K5fkiyumjYrZk4MtkxOqVIUtU08rat0rZZUO0T+KkNHvjbZ487XvLQjN1g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.16.0.tgz",
+      "integrity": "sha512-u9zTj6BcUmqknrcikrunRpkRr+uQlENhgK/m0Zokxtv9CgkmNzR8oLoseJjU5P4zGZEiJE/v7wnzNC1ezvS9nQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.4.tgz",
-      "integrity": "sha512-BxcJpBu8D3kv/GZkx/gSMz6VnTJREBj/4lbzYOQueUOELkt8WrO6zAcSPmp9uRPEW/d+lUO8QK0W2xnS1hEU0A==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true,
       "optional": true
     },
@@ -1374,9 +1374,9 @@
       }
     },
     "ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1473,9 +1473,9 @@
       }
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -1974,9 +1974,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "percy exec --testing -- dotnet test"
   },
   "devDependencies": {
-    "@percy/cli": "^1.12.0"
+    "@percy/cli": "^1.16.0"
   }
 }


### PR DESCRIPTION
* in `v1.15.0` release of `@percy/cli` we introduced a change where we were passing an object from `PercyDOM.serialize` function which broke type conversion in the dotnet SDK. 
* we're now using implicit type conversion `var` to avoid this scenario from happening

fixes #42 