### PR TITLE
Fixing GetCapabilities method for 4.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - uses: actions/cache@v3
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}/nuget-5.0.x/${{ hashFiles('**/packages.lock.json') }}
-          restore-keys: ${{ runner.os }}/nuget-5.0.x/
+          key: ${{ runner.os }}/nuget-6.0.x/${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: ${{ runner.os }}/nuget-6.0.x/
       - uses: actions/cache@v3
         with:
           path: node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}/node-16/${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}/node-16/
+      - name: Install SSL libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl1.1 libssl-dev
       - name: Install Dependencies
         run: dotnet restore && npm install
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}/node-16/${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}/node-16/
-      - name: Install SSL libraries
+      - name: Install OpenSSL 1.1
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl1.1 libssl-dev
+          wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb
       - name: Install Dependencies
         run: dotnet restore && npm install
         env:

--- a/Percy/IPercySeleniumDriver.cs
+++ b/Percy/IPercySeleniumDriver.cs
@@ -6,7 +6,7 @@ namespace PercyIO.Selenium
 {
   internal interface IPercySeleniumDriver
   {
-    ICapabilities GetCapabilities();
+    System.Collections.Generic.Dictionary<string, object> GetCapabilities();
     System.Collections.Generic.IDictionary<string, object> GetSessionDetails();
     String sessionId();
     String GetElementIdFromElement(IWebElement element);

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -391,7 +391,8 @@ namespace PercyIO.Selenium
                 {
                     if(o.Key == "capabilities")
                     {
-                        var capabilitiesJson = JsonSerializer.Serialize(o.Value);
+                        var capabilitiesString = JsonSerializer.Serialize(o.Value);
+                        var capabilitiesJson = JObject.Parse(capabilitiesString);
                         screenshotOptions.Add(o.Key, capabilitiesJson);
                     } else
                     {

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -391,8 +391,8 @@ namespace PercyIO.Selenium
                 {
                     if(o.Key == "capabilities")
                     {
-                        var dictionary = JObject.Parse(o.Value.ToString());
-                        screenshotOptions.Add(o.Key, dictionary);
+                        var capabilitiesJson = JsonSerializer.Serialize(o.Value);
+                        screenshotOptions.Add(o.Key, capabilitiesJson);
                     } else
                     {
                         screenshotOptions.Add(o.Key, o.Value);

--- a/Percy/PercySeleniumDriver.cs
+++ b/Percy/PercySeleniumDriver.cs
@@ -38,15 +38,23 @@ namespace PercyIO.Selenium
     return this._remoteDriver;
   }
 
-  public ICapabilities GetCapabilities()
+  public Dictionary<string, object> GetCapabilities()
   {
-    // Implement Cache
     var key = "caps_" + sessionId();
     if (PercyDriver.cache.Get(key) == null) {
       object capabilities = this._remoteDriver.Capabilities;
-      PercyDriver.cache.Store(key, capabilities);
+      var capabilitiesType = capabilities.GetType();
+      var dictionaryField = capabilitiesType.GetField("capabilities", BindingFlags.NonPublic | BindingFlags.Instance);
+      
+      if (dictionaryField != null){
+        var capabilitiesDictionary = dictionaryField.GetValue(capabilities) as Dictionary<string, object>;
+        if (capabilitiesDictionary != null){
+          PercyDriver.cache.Store(key, capabilitiesDictionary);
+        }
+      }
     }
-    return (ICapabilities)PercyDriver.cache.Get(key);
+    
+    return PercyDriver.cache.Get(key) as Dictionary<string, object>;
   }
 
   public IDictionary<string, object> GetSessionDetails()


### PR DESCRIPTION
For Selenium Version 4.27+ there is a change in `this._remoteDriver.Capabilities;`
Till version 4.26 we used to get the Dictionary of all Capabilities.
From Version 4.27 its is noticed we are only getting `OpenQA.Selenium.Internal.ReturnedCapabilities`.
Resolved it by fetching the capabilities using GetField function.