### PR TITLE
feat: PER-7348 add waitForReady() call before serialize()

### DIFF
--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -338,6 +338,46 @@ namespace PercyIO.Selenium.Tests
             }
             Percy.Enabled = oldEnabledFn;
         }
+
+        // --- Readiness gate (PER-7348) --------------------------------------
+
+        [Fact]
+        public void PostsSnapshotWithReadinessEnabled()
+        {
+            // preset=balanced → SDK calls PercyDOM.waitForReady via ExecuteAsyncScript
+            // before serialize. Snapshot still posts normally regardless of whether
+            // the connected CLI exposes waitForReady (typeof guard in the script).
+            Percy.Snapshot(driver, "readiness-balanced", new {
+                readiness = new { preset = "balanced" }
+            });
+
+            JsonElement data = Request("/test/logs");
+            List<string> logs = new List<string>();
+            foreach (JsonElement log in data.GetProperty("logs").EnumerateArray())
+            {
+                string? msg = log.GetProperty("message").GetString();
+                if (msg != null) logs.Add(msg);
+            }
+            Assert.Contains("Received snapshot: readiness-balanced", logs);
+        }
+
+        [Fact]
+        public void PostsSnapshotWithReadinessDisabled()
+        {
+            // preset=disabled → SDK skips the ExecuteAsyncScript. Snapshot still posts.
+            Percy.Snapshot(driver, "readiness-disabled", new {
+                readiness = new { preset = "disabled" }
+            });
+
+            JsonElement data = Request("/test/logs");
+            List<string> logs = new List<string>();
+            foreach (JsonElement log in data.GetProperty("logs").EnumerateArray())
+            {
+                string? msg = log.GetProperty("message").GetString();
+                if (msg != null) logs.Add(msg);
+            }
+            Assert.Contains("Received snapshot: readiness-disabled", logs);
+        }
     }
     public class RegionTests
     {

--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -99,7 +99,7 @@ namespace PercyIO.Selenium.Tests
             if (msg.Contains("SDK Version Check") || msg.Contains("\"cores\":") || msg.Contains("memoryInfo"))
                 return false;
             // Drop CLI-side readiness gate logs ("Readiness passed in 321ms ...",
-            // "- readiness.preset:", "- readiness_diagnostics:", etc.) so PER-7348
+            // "- readiness.preset:", "- readiness_diagnostics:", etc.) so 
             // changes don't perturb existing per-snapshot log assertions.
             if (msg.StartsWith("Readiness ") || msg.Contains("readiness"))
                 return false;
@@ -344,7 +344,7 @@ namespace PercyIO.Selenium.Tests
             Percy.Enabled = oldEnabledFn;
         }
 
-        // --- Readiness gate (PER-7348) --------------------------------------
+        // --- Readiness gate --------------------------------------
 
         [Fact]
         public void PostsSnapshotWithReadinessEnabled()

--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -98,6 +98,11 @@ namespace PercyIO.Selenium.Tests
             // Always drop SDK version check banners and memory dumps
             if (msg.Contains("SDK Version Check") || msg.Contains("\"cores\":") || msg.Contains("memoryInfo"))
                 return false;
+            // Drop CLI-side readiness gate logs ("Readiness passed in 321ms ...",
+            // "- readiness.preset:", "- readiness_diagnostics:", etc.) so PER-7348
+            // changes don't perturb existing per-snapshot log assertions.
+            if (msg.StartsWith("Readiness ") || msg.Contains("readiness"))
+                return false;
             // For "- key: value" config lines keep only the essential known set
             if (Regex.IsMatch(msg, @"^- [a-zA-Z.]+: "))
                 return _essentialConfigPrefixes.Any(p => msg.StartsWith(p));

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -392,16 +392,75 @@ namespace PercyIO.Selenium
             };
         }
 
+        // Readiness gate (PER-7348): runs PercyDOM.waitForReady via
+        // ExecuteAsyncScript (callback signal) BEFORE serialize. Graceful on
+        // old CLIs that lack waitForReady. Returns diagnostics for attachment.
+        internal static object? WaitForReady(WebDriver driver, Dictionary<string, object>? options)
+        {
+            string readinessJson = "{}";
+            if (options != null && options.TryGetValue("readiness", out var perSnapshot) && perSnapshot != null)
+            {
+                readinessJson = JsonSerializer.Serialize(perSnapshot);
+            }
+            else if (cliConfig is JsonElement cfg &&
+                     cfg.ValueKind == JsonValueKind.Object &&
+                     cfg.TryGetProperty("snapshot", out JsonElement snap) &&
+                     snap.ValueKind == JsonValueKind.Object &&
+                     snap.TryGetProperty("readiness", out JsonElement rd) &&
+                     rd.ValueKind == JsonValueKind.Object)
+            {
+                readinessJson = rd.GetRawText();
+            }
+
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(readinessJson);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                    doc.RootElement.TryGetProperty("preset", out JsonElement presetEl) &&
+                    presetEl.ValueKind == JsonValueKind.String &&
+                    presetEl.GetString() == "disabled")
+                {
+                    return null;
+                }
+            }
+            catch { /* fall through */ }
+
+            string script =
+                "var cfg = " + readinessJson + ";"
+                + "var done = arguments[arguments.length - 1];"
+                + "try {"
+                + "  if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {"
+                + "    PercyDOM.waitForReady(cfg).then(function(r){ done(r); }).catch(function(){ done(); });"
+                + "  } else { done(); }"
+                + "} catch (e) { done(); }";
+            try
+            {
+                return driver.ExecuteAsyncScript(script);
+            }
+            catch (Exception e)
+            {
+                Log($"waitForReady failed, proceeding to serialize: {e.Message}", "debug");
+                return null;
+            }
+        }
+
         private static dynamic getSerializedDom(
             WebDriver driver,
             object cookies,
             Dictionary<string, object>? options,
             string? domJs = null)
         {
+            // Readiness gate before serialize (PER-7348). Graceful on old CLI.
+            object? readinessDiagnostics = WaitForReady(driver, options);
+
             var opts = JsonSerializer.Serialize(options);
             string script = $"return PercyDOM.serialize({opts})";
             var domSnapshot = (Dictionary<string, object>)driver.ExecuteScript(script);
             domSnapshot["cookies"] = cookies;
+            if (readinessDiagnostics != null)
+            {
+                domSnapshot["readiness_diagnostics"] = readinessDiagnostics;
+            }
 
             // Process CORS iframes when DOM script is available
             if (!string.IsNullOrEmpty(domJs))

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -392,7 +392,7 @@ namespace PercyIO.Selenium
             };
         }
 
-        // Readiness gate (PER-7348): runs PercyDOM.waitForReady via
+        // Readiness gate: runs PercyDOM.waitForReady via
         // ExecuteAsyncScript (callback signal) BEFORE serialize. Graceful on
         // old CLIs that lack waitForReady. Returns diagnostics for attachment.
         //
@@ -502,7 +502,7 @@ namespace PercyIO.Selenium
             Dictionary<string, object>? options,
             string? domJs = null)
         {
-            // Readiness gate before serialize (PER-7348). Graceful on old CLI.
+            // Readiness gate before serialize. Graceful on old CLI.
             object? readinessDiagnostics = WaitForReady(driver, options);
 
             // Strip `readiness` from forwarded serialize args — it's consumed by

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -395,35 +395,34 @@ namespace PercyIO.Selenium
         // Readiness gate (PER-7348): runs PercyDOM.waitForReady via
         // ExecuteAsyncScript (callback signal) BEFORE serialize. Graceful on
         // old CLIs that lack waitForReady. Returns diagnostics for attachment.
+        //
+        // Config precedence: per-snapshot options["readiness"] is shallow-
+        // merged over cliConfig.snapshot.readiness so a partial per-snapshot
+        // override inherits global keys (notably preset: disabled).
         internal static object? WaitForReady(WebDriver driver, Dictionary<string, object>? options)
         {
-            string readinessJson = "{}";
-            if (options != null && options.TryGetValue("readiness", out var perSnapshot) && perSnapshot != null)
+            var readiness = ResolveReadinessConfig(options);
+            string readinessJson = JsonSerializer.Serialize(readiness);
+
+            if (readiness.TryGetValue("preset", out var preset) && (preset as string) == "disabled")
             {
-                readinessJson = JsonSerializer.Serialize(perSnapshot);
-            }
-            else if (cliConfig is JsonElement cfg &&
-                     cfg.ValueKind == JsonValueKind.Object &&
-                     cfg.TryGetProperty("snapshot", out JsonElement snap) &&
-                     snap.ValueKind == JsonValueKind.Object &&
-                     snap.TryGetProperty("readiness", out JsonElement rd) &&
-                     rd.ValueKind == JsonValueKind.Object)
-            {
-                readinessJson = rd.GetRawText();
+                return null;
             }
 
-            try
+            // Match the driver's async-script timeout to readiness.timeoutMs so
+            // a higher user-configured timeout isn't silently capped by WebDriver.
+            TimeSpan? previousTimeout = null;
+            if (readiness.TryGetValue("timeoutMs", out var timeoutObj) &&
+                TryToLong(timeoutObj, out long timeoutMs) && timeoutMs > 0)
             {
-                using JsonDocument doc = JsonDocument.Parse(readinessJson);
-                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
-                    doc.RootElement.TryGetProperty("preset", out JsonElement presetEl) &&
-                    presetEl.ValueKind == JsonValueKind.String &&
-                    presetEl.GetString() == "disabled")
+                try
                 {
-                    return null;
+                    previousTimeout = driver.Manage().Timeouts().AsynchronousJavaScript;
+                    driver.Manage().Timeouts().AsynchronousJavaScript =
+                        TimeSpan.FromMilliseconds(timeoutMs + 2000);
                 }
+                catch { previousTimeout = null; /* best-effort */ }
             }
-            catch { /* fall through */ }
 
             string script =
                 "var cfg = " + readinessJson + ";"
@@ -442,6 +441,59 @@ namespace PercyIO.Selenium
                 Log($"waitForReady failed, proceeding to serialize: {e.Message}", "debug");
                 return null;
             }
+            finally
+            {
+                if (previousTimeout.HasValue)
+                {
+                    try { driver.Manage().Timeouts().AsynchronousJavaScript = previousTimeout.Value; }
+                    catch { /* best-effort */ }
+                }
+            }
+        }
+
+        private static bool TryToLong(object? value, out long result)
+        {
+            result = 0;
+            if (value == null) return false;
+            try { result = Convert.ToInt64(value); return true; }
+            catch { return false; }
+        }
+
+        // Shallow-merge of global (cliConfig.snapshot.readiness) and per-snapshot
+        // (options["readiness"]) readiness config. Per-snapshot keys win.
+        private static Dictionary<string, object?> ResolveReadinessConfig(Dictionary<string, object>? options)
+        {
+            var merged = new Dictionary<string, object?>();
+            if (cliConfig is JsonElement cfg &&
+                cfg.ValueKind == JsonValueKind.Object &&
+                cfg.TryGetProperty("snapshot", out JsonElement snap) &&
+                snap.ValueKind == JsonValueKind.Object &&
+                snap.TryGetProperty("readiness", out JsonElement rd) &&
+                rd.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in rd.EnumerateObject())
+                {
+                    merged[prop.Name] = JsonElementToObject(prop.Value);
+                }
+            }
+            if (options != null && options.TryGetValue("readiness", out var perSnapshot) && perSnapshot is Dictionary<string, object> perDict)
+            {
+                foreach (var kv in perDict) merged[kv.Key] = kv.Value;
+            }
+            return merged;
+        }
+
+        private static object? JsonElementToObject(JsonElement el)
+        {
+            return el.ValueKind switch
+            {
+                JsonValueKind.String => el.GetString(),
+                JsonValueKind.Number => el.TryGetInt64(out var l) ? (object)l : el.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => el.GetRawText()
+            };
         }
 
         private static dynamic getSerializedDom(
@@ -453,7 +505,15 @@ namespace PercyIO.Selenium
             // Readiness gate before serialize (PER-7348). Graceful on old CLI.
             object? readinessDiagnostics = WaitForReady(driver, options);
 
-            var opts = JsonSerializer.Serialize(options);
+            // Strip `readiness` from forwarded serialize args — it's consumed by
+            // WaitForReady upstream, not a PercyDOM.serialize argument.
+            var serializeOptions = options;
+            if (options != null && options.ContainsKey("readiness"))
+            {
+                serializeOptions = new Dictionary<string, object>(options);
+                serializeOptions.Remove("readiness");
+            }
+            var opts = JsonSerializer.Serialize(serializeOptions);
             string script = $"return PercyDOM.serialize({opts})";
             var domSnapshot = (Dictionary<string, object>)driver.ExecuteScript(script);
             domSnapshot["cookies"] = cookies;
@@ -842,7 +902,14 @@ namespace PercyIO.Selenium
 
                 if (options != null)
                     foreach (KeyValuePair<string, object> o in options)
+                    {
+                        // `readiness` is SDK-local — the CLI already has it via
+                        // healthcheck. Strip from POST body so we don't round-
+                        // trip and we stay forward-compatible with future
+                        // CLI-side validators.
+                        if (o.Key == "readiness") continue;
                         snapshotOptions.Add(o.Key, o.Value);
+                    }
 
                 dynamic res = Request("/percy/snapshot", snapshotOptions);
                 dynamic data = JsonSerializer.Deserialize<object>(res.content);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "percy exec --testing -- dotnet test"
   },
   "devDependencies": {
-    "@percy/cli": "^1.31.10"
+    "@percy/cli": "^1.31.15-beta.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts the readiness gate from [percy/cli#2184](https://github.com/percy/cli/pull/2184) (PER-7348). New `WaitForReady(driver, options)` internal helper runs `PercyDOM.waitForReady` via `ExecuteAsyncScript` (callback signal) before the existing serialize `ExecuteScript` inside `getSerializedDom`. Diagnostics are attached to the snapshot as `readiness_diagnostics`. Serialize is unchanged.

### Contract

- Config precedence: `options["readiness"]` → `cliConfig.snapshot.readiness` → empty (CLI `balanced` default)
- Backward compat: in-browser `typeof PercyDOM.waitForReady === 'function'` guard
- Disabled preset short-circuits
- Graceful: rejection/exception logged at debug; serialize still runs

### Tests

Two `[Fact]` tests in `UnitTests`:

- ✅ **PostsSnapshotWithReadinessEnabled** — `readiness: { preset: "balanced" }` → snapshot posts
- ✅ **PostsSnapshotWithReadinessDisabled** — `readiness: { preset: "disabled" }` → snapshot posts

## Test results

| Check | Status | Notes |
|---|---|---|
| Build (`dotnet build Percy/Percy.csproj`) | ✅ **pass, 0 errors** | Only pre-existing warnings |
| Unit tests (`dotnet test`) | ⚠️ not executed locally | Test project targets net10.0 (pre-existing, unrelated to this PR); this machine has .NET 9. Reviewer to run with .NET 10 SDK |
| Smoke test | ⚠️ skipped: toolchain missing | |

## Related

- CLI PR: [percy/cli#2184](https://github.com/percy/cli/pull/2184)