### PR TITLE
release v2.1.5-beta.2

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Selenium</PackageId>
     <Description>Percy for Selenium WebDriver API .NET Bindings</Description>
     <PackageTags>selenium;percy;visual;testing</PackageTags>
-    <Version>2.1.5-beta.1</Version>
+    <Version>2.1.5-beta.2</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>


### PR DESCRIPTION
Bumps the SDK to the next beta (`2.1.5-beta.1` → `2.1.5-beta.2`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)