### PR TITLE
chore: release 2.1.5

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Selenium</PackageId>
     <Description>Percy for Selenium WebDriver API .NET Bindings</Description>
     <PackageTags>selenium;percy;visual;testing</PackageTags>
-    <Version>2.1.5-beta.2</Version>
+    <Version>2.1.5</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `2.1.5-beta.2` to stable `2.1.5`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.