### PR TITLE
fix(PER-9537): set ignore-scripts=true in .npmrc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 version: 2
+# Wait 7 days before proposing updates to newly published versions, so a
+# compromised/unstable release has time to be caught and yanked.
 updates:
 - package-ecosystem: npm
   directory: /
@@ -8,6 +10,8 @@ updates:
     interval: weekly
   commit-message:
     prefix: ⬆️
+  cooldown:
+    default-days: 7
 - package-ecosystem: nuget
   directory: /
   labels:
@@ -16,6 +20,8 @@ updates:
     interval: weekly
   commit-message:
     prefix: ⬆️
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -24,3 +30,5 @@ updates:
     prefix: ⬆️👷
   labels:
     - ⬆️⬇️ dependencies
+  cooldown:
+    default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: 6.0.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}/nuget-6.0.x/${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           stale-issue-message: >-
             This issue is stale because it has been open for more than 14 days with no activity.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: regex-match
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
@@ -23,16 +23,16 @@ jobs:
       - name: Break on invalid branch name
         run: exit 1
         if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: 6.0.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}/nuget-6.0.x/${{ hashFiles('**/packages.lock.json') }}
           restore-keys: ${{ runner.os }}/nuget-6.0.x/
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: node_modules
           key: ${{ runner.os }}/node-16/${{ hashFiles('**/package-lock.json') }}
@@ -47,9 +47,13 @@ jobs:
           PERCY_POSTINSTALL_BROWSER: true
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          # Pass the untrusted workflow_dispatch input through an env var instead
+          # of interpolating it directly into the shell (run-shell-injection).
+          PERCY_CLI_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           cd /tmp
-          git clone --branch ${{ github.event.inputs.branch }} --depth 1 https://github.com/percy/cli
+          git clone --branch "$PERCY_CLI_BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -type d -depth 1 | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           git log -1

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-ignore-scripts=false
+ignore-scripts=true
 strict-ssl=true
 save-exact=true
 audit-level=high

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ save-exact=true
 audit-level=high
 engine-strict=true
 legacy-peer-deps=false
+min-release-age=7


### PR DESCRIPTION
## Summary
- Weekly supply-chain `.npmrc` audit ([PER-9537](https://browserstack.atlassian.net/browse/PER-9537)) flagged `ignore-scripts=false`, which allows npm lifecycle scripts (preinstall/postinstall) to run unchecked during install — the exact vector malicious/typosquatted packages rely on.
- Flips it to `ignore-scripts=true` per the required hardening directives in the audit spec.

Fixes PER-9537

[PER-9537]: https://browserstack.atlassian.net/browse/PER-9537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ